### PR TITLE
Add restartable server script

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,5 +14,9 @@ endpoint that returns the text `world`.
    ```bash
    npm start
    ```
-3. Open your browser to `http://localhost:3000` and you should see
+3. Start or restart the server using the helper script:
+   ```bash
+   npm run start-server
+   ```
+4. Open your browser to `http://localhost:3000` and you should see
    **Hello world!** displayed.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Simple Node.js starter web app",
   "main": "server.js",
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "start-server": "./start-server.sh"
   },
   "dependencies": {
     "express": "^4.18.2"

--- a/start-server.sh
+++ b/start-server.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# Start or restart the Node.js server
+
+# Attempt to kill any running instance of server.js
+if pgrep -f "node\s*server.js" > /dev/null; then
+  echo "Restarting existing server..."
+  pkill -f "node\s*server.js"
+else
+  echo "Starting server..."
+fi
+
+# Start the server in the background
+node server.js &
+
+


### PR DESCRIPTION
## Summary
- add `start-server.sh` to restart Node server if it's already running
- expose new `start-server` npm script
- document how to use the helper script

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68486beb979c832e9b04117757d88ad8