### PR TITLE
Ensure Codespaces port detection

### DIFF
--- a/start-server.sh
+++ b/start-server.sh
@@ -10,7 +10,8 @@ else
   echo "Starting server..."
 fi
 
-# Start the server in the background
-node server.js &
+# Start the server in the foreground to ensure Codespaces
+# properly detects the port and offers the Open in Browser link
+node server.js
 
 


### PR DESCRIPTION
## Summary
- run Node server in the foreground so GitHub Codespaces can pick up the open port

No test directories exist outside of `node_modules`, so no further removals were needed.

## Testing
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_68486f753cec832e8856d641f2773d57