### PR TITLE
Add VS Code launch config to run server

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,13 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Run Server",
+      "type": "node",
+      "request": "launch",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "start-server"],
+      "console": "integratedTerminal"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add `.vscode/launch.json` for debugging

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684876df036c832ead1c27bda736266c