### PR TITLE
Add devcontainer setup with npm install hooks

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,6 @@
+{
+  "name": "starter-web-project-nodejs",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:18-bullseye",
+  "postCreateCommand": "npm install && git config --local core.hooksPath .githooks",
+  "postStartCommand": "npm install"
+}

--- a/.githooks/post-merge
+++ b/.githooks/post-merge
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+if [ -f package.json ]; then
+  echo "Running npm install after merge..."
+  npm install
+fi

--- a/README.md
+++ b/README.md
@@ -30,3 +30,8 @@ endpoint that returns the text `world`.
    initialized automatically.
 4. Use the `/increment` endpoint to increase a shared counter stored in
    Firestore. Each call returns the updated value as plain text.
+
+## Development in Codespaces
+
+A `.devcontainer` configuration automates installation of dependencies when the codespace is created. A Git `post-merge` hook also runs `npm install` after you pull new changes to keep dependencies up to date.
+


### PR DESCRIPTION
## Summary
- add devcontainer configuration for Codespaces
- set up `post-merge` git hook to run `npm install`
- document devcontainer behavior in README

## Testing
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_68492cf6907c832e812e4eccf6eb6a42